### PR TITLE
ESLint: No console commands

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,6 +45,7 @@ module.exports = defineConfig([
           suffix: ['Component', 'Service', 'Directive', 'Pipe', 'Guard'],
         },
       ],
+      '@/no-console': ['error'],
     },
   },
   {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,4 +2,6 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
-bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));
+bootstrapApplication(AppComponent, appConfig).catch((err) => {
+  throw err;
+});


### PR DESCRIPTION
Prevents using `console.*()` commands in TypeScript. Also corrects the current usage of it.