### PR TITLE
Add `completed_on` field for order items

### DIFF
--- a/src/app/order-item/order-item.model.ts
+++ b/src/app/order-item/order-item.model.ts
@@ -13,4 +13,5 @@ export interface OrderItem {
   listingDescription?: string | null;
   listingImageUrl?: string | null;
   shippedOn?: string | null;
+  completedOn?: string | null;
 }


### PR DESCRIPTION
Makes the `completedOn` field visible for the front end order items to use.