### PR TITLE
Fixed loading issue with purchases page

### DIFF
--- a/src/app/purchases/purchases.component.ts
+++ b/src/app/purchases/purchases.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { OrderService } from '../order/order.service';
-import { UserStore } from '../core/stores/user.store';
 import { Paginator } from '../shared/utils/paginator';
 import { Order } from '../order/order.model';
 import { MessageService } from '../shared/message/message.service';
@@ -8,6 +7,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { MatAccordion } from '@angular/material/expansion';
 import { OrderComponent } from '../order/ui/order.component';
 import { MatPaginator } from '@angular/material/paginator';
+import { AuthService } from '../auth/auth.service';
 
 @Component({
   selector: 'app-purchases',
@@ -19,14 +19,12 @@ export class PurchasesComponent implements OnInit {
   readonly paginatorOrders = new Paginator<Order>(10);
 
   private readonly orderService = inject(OrderService);
-  private readonly userStore = inject(UserStore);
+  private readonly auth = inject(AuthService);
   private readonly messageService = inject(MessageService);
 
   ngOnInit(): void {
-    const user = this.userStore.user()!;
-
     // Load orders
-    this.orderService.getOrdersByUserId(user.id).subscribe({
+    this.orderService.getOrdersByUserId(this.auth.userId!).subscribe({
       next: (orders) => this.paginatorOrders.setItems(orders),
       error: (err: HttpErrorResponse) => this.messageService.error(err.message),
     });


### PR DESCRIPTION
Purchases were not loading on refresh because it was grabbing the user ID from the user store instead of the authentication service.